### PR TITLE
Make generated (main) BOM publishable

### DIFF
--- a/bom-builder3/src/main/java/eu/maneniverse/maven/plugins/bombuilder/BuildBomMojo.java
+++ b/bom-builder3/src/main/java/eu/maneniverse/maven/plugins/bombuilder/BuildBomMojo.java
@@ -308,6 +308,21 @@ public class BuildBomMojo extends AbstractMojo {
         if (bomDescription != null) {
             pomModel.setDescription(bomDescription);
         }
+
+        if (attach && (bomClassifier == null || bomClassifier.trim().isEmpty())) {
+            // standalone main BOM POM; inherit required things for publishing for "this" project
+            if (bomName == null) {
+                pomModel.setName(mavenProject.getModel().getName());
+            }
+            if (bomDescription == null) {
+                pomModel.setDescription(mavenProject.getModel().getDescription());
+            }
+            pomModel.setUrl(mavenProject.getModel().getUrl());
+            pomModel.setLicenses(mavenProject.getModel().getLicenses());
+            pomModel.setDevelopers(mavenProject.getModel().getDevelopers());
+            pomModel.setScm(mavenProject.getModel().getScm());
+        }
+
         return pomModel;
     }
 

--- a/it3/src/it/reactor-with-bom-module-fat/bom/pom.xml
+++ b/it3/src/it/reactor-with-bom-module-fat/bom/pom.xml
@@ -12,7 +12,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd" child.project.url.inherit.append.path="false" >
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/it3/src/it/reactor-with-bom-module-fat/expected/pom.xml
+++ b/it3/src/it/reactor-with-bom-module-fat/expected/pom.xml
@@ -6,6 +6,20 @@
   <artifactId>bom</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+  <description>Test to create reactor bom description</description>
+  <url>https://maveniverse.eu/bom/bom/</url>
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:git@github.com:maveniverse/bom-builder-maven-plugin.git/bom</connection>
+    <developerConnection>scm:git:git@github.com:maveniverse/bom-builder-maven-plugin.git/bom</developerConnection>
+    <url>https://github.com/maveniverse/bom-builder-maven-plugin/bom</url>
+  </scm>
   <properties>
     <version.org.slf4j>1.7.36</version.org.slf4j>
     <version.reactor-with-bom-module-fat>1.0-SNAPSHOT</version.reactor-with-bom-module-fat>

--- a/it3/src/it/reactor-with-bom-module-fat/pom.xml
+++ b/it3/src/it/reactor-with-bom-module-fat/pom.xml
@@ -27,6 +27,20 @@
   <packaging>pom</packaging>
 
   <name>Test to create reactor bom</name>
+  <description>Test to create reactor bom description</description>
+  <url>https://maveniverse.eu/bom/</url>
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:git@github.com:maveniverse/bom-builder-maven-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:maveniverse/bom-builder-maven-plugin.git</developerConnection>
+    <url>https://github.com/maveniverse/bom-builder-maven-plugin</url>
+  </scm>
 
   <modules>
     <module>api</module>

--- a/it3/src/it/reactor-with-bom-module-skinny/expected/pom.xml
+++ b/it3/src/it/reactor-with-bom-module-skinny/expected/pom.xml
@@ -6,6 +6,20 @@
   <artifactId>bom</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+  <description>Test to create reactor bom description</description>
+  <url>https://maveniverse.eu/bom/bom/</url>
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:git@github.com:maveniverse/bom-builder-maven-plugin.git/bom</connection>
+    <developerConnection>scm:git:git@github.com:maveniverse/bom-builder-maven-plugin.git/bom</developerConnection>
+    <url>https://github.com/maveniverse/bom-builder-maven-plugin/bom</url>
+  </scm>
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/it3/src/it/reactor-with-bom-module-skinny/pom.xml
+++ b/it3/src/it/reactor-with-bom-module-skinny/pom.xml
@@ -27,6 +27,20 @@
   <packaging>pom</packaging>
 
   <name>Test to create reactor bom</name>
+  <description>Test to create reactor bom description</description>
+  <url>https://maveniverse.eu/bom/</url>
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:git@github.com:maveniverse/bom-builder-maven-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:maveniverse/bom-builder-maven-plugin.git</developerConnection>
+    <url>https://github.com/maveniverse/bom-builder-maven-plugin</url>
+  </scm>
 
   <modules>
     <module>api</module>


### PR DESCRIPTION
When used in "replace" mode, the POM must fit some requirements, for example to be publish-able to
Maven Central.

In that case, plugin inherits/uses original model values on fields it needs to fill in.