### PR TITLE
Fix Maven 4 consumer POM compatibility for BOM replace mode

### DIFF
--- a/bom-builder3/src/main/java/eu/maneniverse/maven/plugins/bombuilder/BuildBomMojo.java
+++ b/bom-builder3/src/main/java/eu/maneniverse/maven/plugins/bombuilder/BuildBomMojo.java
@@ -292,6 +292,39 @@ public class BuildBomMojo extends AbstractMojo {
                     && mavenProject.getModules().isEmpty()) {
                 getLog().debug("Replacing module POM w/ generated BOM");
                 mavenProject.setFile(outputFile.toFile());
+                // Maven 4 consumer POM compatibility: Maven 4's consumer POM transformer
+                // captures the source POM path eagerly (before mojos run) and lazily reads
+                // its content at install time. The setFile() call above has no effect on the
+                // consumer POM because its TransformedArtifact reads from the captured path.
+                //
+                // Fix: if Maven 4 has attached a consumer POM artifact (classifier="consumer"),
+                // replace it with a plain artifact pointing to our generated BOM.
+                // MavenProject.addAttachedArtifact() replaces existing artifacts with the same
+                // coordinates via indexOf+set on the internal mutable list, so this effectively
+                // swaps the TransformedArtifact for our BOM. At install time, Maven 4's
+                // remapInstallArtifacts() promotes the consumer-classified artifact to the main
+                // .pom, so consumers will see the generated BOM.
+                boolean consumerPomReplaced = false;
+                for (Artifact attached : mavenProject.getAttachedArtifacts()) {
+                    if ("consumer".equals(attached.getClassifier()) && "pom".equals(attached.getType())) {
+                        DefaultArtifact consumerArtifact = new DefaultArtifact(
+                                mavenProject.getGroupId(),
+                                mavenProject.getArtifactId(),
+                                mavenProject.getVersion(),
+                                null,
+                                "pom",
+                                "consumer",
+                                attached.getArtifactHandler());
+                        consumerArtifact.setFile(outputFile.toFile());
+                        mavenProject.addAttachedArtifact(consumerArtifact);
+                        consumerPomReplaced = true;
+                        getLog().debug("Replaced consumer POM artifact for Maven 4 compatibility");
+                        break;
+                    }
+                }
+                if (!consumerPomReplaced) {
+                    getLog().debug("No consumer POM artifact found (Maven 3 or consumer POM disabled)");
+                }
             } else {
                 throw new MojoExecutionException(
                         "Cannot replace project POM: invalid project (packaging=pom w/o modules)");

--- a/it3/src/it/reactor-with-bom-module-fat/verify.groovy
+++ b/it3/src/it/reactor-with-bom-module-fat/verify.groovy
@@ -20,3 +20,18 @@ if (isDifferent) {
     System.err.println(diff)
     return false
  }
+
+// Verify the installed POM in the local repository also contains the generated BOM content.
+// This catches Maven 4 consumer POM issues: the consumer POM transformer may install a stripped
+// POM that lacks dependencyManagement if the plugin does not handle the transformer correctly.
+File installedPom = new File(localRepositoryPath, "reactor-with-bom-module-fat/bom/1.0-SNAPSHOT/bom-1.0-SNAPSHOT.pom")
+if (!installedPom.exists()) {
+    System.err.println("Installed POM not found: " + installedPom.absolutePath)
+    return false
+}
+String installedPomContents = installedPom.getText('UTF-8')
+if (!installedPomContents.contains('<dependencyManagement>')) {
+    System.err.println("Installed POM does not contain <dependencyManagement>: " + installedPom.absolutePath)
+    System.err.println("This indicates the Maven 4 consumer POM does not include the generated BOM content.")
+    return false
+}

--- a/it3/src/it/reactor-with-bom-module-skinny/verify.groovy
+++ b/it3/src/it/reactor-with-bom-module-skinny/verify.groovy
@@ -16,3 +16,18 @@ if (isDifferent) {
     System.err.println(diff)
     return false
  }
+
+// Verify the installed POM in the local repository also contains the generated BOM content.
+// This catches Maven 4 consumer POM issues: the consumer POM transformer may install a stripped
+// POM that lacks dependencyManagement if the plugin does not handle the transformer correctly.
+File installedPom = new File(localRepositoryPath, "reactor-with-bom-module-skinny/bom/1.0-SNAPSHOT/bom-1.0-SNAPSHOT.pom")
+if (!installedPom.exists()) {
+    System.err.println("Installed POM not found: " + installedPom.absolutePath)
+    return false
+}
+String installedPomContents = installedPom.getText('UTF-8')
+if (!installedPomContents.contains('<dependencyManagement>')) {
+    System.err.println("Installed POM does not contain <dependencyManagement>: " + installedPom.absolutePath)
+    System.err.println("This indicates the Maven 4 consumer POM does not include the generated BOM content.")
+    return false
+}


### PR DESCRIPTION
## Summary

- Fix BOM replace mode (`attach=true`, no classifier) under Maven 4: the installed `.pom` now contains the generated BOM with `<dependencyManagement>`, not the original stub POM
- No source POM files are modified — the fix works entirely through Maven's attached artifact API
- Fully backward compatible with Maven 3 (no behavior change)

## Problem

Maven 4 introduces a consumer POM feature: `ConsumerPomArtifactTransformer` captures the source POM path **before** any mojos run and lazily reads its content at install time via `TransformedArtifact`. The existing `setFile()` call has no effect because:
1. `TransformedArtifact.setFile()` throws `UnsupportedOperationException`  
2. The transformer reads from the originally captured path, ignoring `project.setFile()`

As a result, the installed `.pom` under Maven 4 contains the original stub POM (no `<dependencyManagement>`) — the generated BOM only appears as `-build.pom` that consumers never see.

## Fix

After `setFile()`, detect if Maven 4 has attached a consumer POM artifact (classifier=`"consumer"`, type=`"pom"`) and replace it with a plain `DefaultArtifact` pointing to the generated BOM. `MavenProject.addAttachedArtifact()` deduplicates by coordinates (`indexOf` + `set` on the internal mutable list), so this swaps the `TransformedArtifact` for our BOM. At install time, Maven 4's `remapInstallArtifacts()` promotes the consumer artifact to the main `.pom`.

On Maven 3, the loop finds no consumer artifact and falls through — `setFile()` handles everything as before.

## Test plan

- [x] All 9 existing ITs pass on Maven 3.9.16
- [x] All 9 existing ITs pass on Maven 4.0.0-RC-6
- [x] Enhanced `reactor-with-bom-module-fat` and `reactor-with-bom-module-skinny` verify scripts to check the installed `.pom` in the local repository contains `<dependencyManagement>` (this would have caught the original bug)
- [x] Verified installed `.pom` under Maven 4 contains full BOM content with properties preserved (`${version.org.slf4j}`)
- [x] Verified source `bom/pom.xml` is NOT modified by the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BOM generation now correctly replaces attached Maven 4 consumer POM artifacts with the generated BOM artifact.
  * Improved reporting when a consumer POM artifact is replaced or unavailable.
  * Verified that generated BOM POMs are installed locally and contain dependency management information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->